### PR TITLE
Basic view support/Bug fix

### DIFF
--- a/fullcalendar-rightclick.js
+++ b/fullcalendar-rightclick.js
@@ -5,18 +5,28 @@
  */
 
 (function($) {
-	function monkeyPatchViewClass(View, dayCssClass) {
+	function monkeyPatchViewClass(View) {
 		View = View.class || View;
 		var renderFn = 'render' in View.prototype ? 'render' : 'renderDates';
 		var originalRender = View.prototype[renderFn];
+		var classes = new Array();
+		var daySelector = "";
+		
+		for (idx = 1; idx < arguments.length; idx++) {
+		    classes.push('.fc-widget-content ' + arguments[idx]);
+		}
+		daySelector = classes.join();
+
 		View.prototype[renderFn] = function() {
 			originalRender.call(this);
 			this.registerDayRightclickListener();
 			this.registerEventRightclickListener();
 		};
 		View.prototype.registerDayRightclickListener = function() {
-			var that = this;
-			this.el.on('contextmenu', '.fc-widget-content ' + dayCssClass,
+		    var that = this;
+
+		    this.el.off('contextmenu', daySelector);
+		    this.el.on('contextmenu', daySelector,
 				function(ev) {
 					that.coordMap.build();
 					var cell = that.coordMap.getCell(ev.pageX, ev.pageY);
@@ -28,7 +38,9 @@
 			);
 		};
 		View.prototype.registerEventRightclickListener = function() {
-			var that = this;
+		    var that = this;
+
+		    this.el.off('contextmenu', '.fc-event-container > *');
 			this.el.on('contextmenu', '.fc-event-container > *', function(ev) {
 				var seg = $(this).data('fc-seg');
 				return that.trigger('eventRightclick', this, seg.event, ev);
@@ -36,6 +48,6 @@
 		}
 	}
 	var fc = $.fullCalendar;
-	monkeyPatchViewClass(fc.views.agenda, '.fc-slats');
-	monkeyPatchViewClass(fc.views.basic, '.fc-content-skeleton');
+	monkeyPatchViewClass(fc.views.agenda, '.fc-slats', '.fc-content-skeleton', '.fc-bg');
+	monkeyPatchViewClass(fc.views.basic, '.fc-content-skeleton', '.fc-bg');
 })(jQuery);


### PR DESCRIPTION
On the month, basicWeek and basicDay views right clicking on a day didn't always raise the right click event and on the agendaWeek and agendaDay views right clicking on the all day events wasn't supported. To support this I modified the monkeyPatchViewClass to support multiple parameters and build the css selector to bind to. After navigating to a new month, week or day multiple right click events get raised. To correct this I call 'off' on the contextmenu event before binding it.
