### PR TITLE
Update to support fullcalendar 2.5+

### DIFF
--- a/fullcalendar-rightclick.js
+++ b/fullcalendar-rightclick.js
@@ -34,8 +34,8 @@
 						'.fc-bgevent-skeleton'
 					);
 					if (fcContainer.length) {
-						that.coordMap.build();
-						var cell = that.coordMap.getCell(ev.pageX, ev.pageY);
+						that.prepareHits();
+                                                var cell = that.queryHit(ev.pageX, ev.pageY);
 						if (cell)
 							return that.trigger(
 								'dayRightclick', null, cell.start, ev


### PR DESCRIPTION
When using FC 2.5 and 2.6, dayRightclick was throwing errors in the console.log about accessing an undefined function coordMap.build(). The newer fullcalendar removed coordMap, so I looked for the new way to get the cell. This works for me now, so passing it along for others.
